### PR TITLE
Allows bulk upload in browsers that support HTML5

### DIFF
--- a/pypln/web/static/css/pypln.css
+++ b/pypln/web/static/css/pypln.css
@@ -24,3 +24,14 @@ label {
 .right {
     text-align: right;
 }
+
+.messages {
+    list-style: none;
+}
+
+.messages>.info {
+    background-color: #72D42A;
+    color: #000;
+    padding: 10px;
+    padding-left: 20px;
+}

--- a/pypln/web/static/css/pypln.css
+++ b/pypln/web/static/css/pypln.css
@@ -34,4 +34,5 @@ label {
     color: #000;
     padding: 10px;
     padding-left: 20px;
+    margin-left: -25px;
 }

--- a/pypln/web/templates/_messages.html
+++ b/pypln/web/templates/_messages.html
@@ -1,0 +1,7 @@
+{% if messages %}
+<ul class="messages">
+    {% for message in messages %}
+    <li{% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message }}</li>
+    {% endfor %}
+</ul>
+{% endif %}


### PR DESCRIPTION
This essentially 2-line patch changes the form to use the [multiple
attribute](http://www.w3.org/TR/html-markup/input.file.html#input.file.attrs.multiple) and uses the old view code to allow upload of more than one file
at once. This code still needs to be refactored and tested, so this is not a
definitive solution, but solves the biggest problem described by
namd/pypln.backend#114.

I don't feel particularly good writing code without tests, so please review this code to see if there is any unintended side effect before we merge it.
