### PR TITLE
Fixes NAMD/pypln.backend#118 (POS tags not unmarking)

### DIFF
--- a/pypln/web/templates/core/visualizations/pos-highlighter.html
+++ b/pypln/web/templates/core/visualizations/pos-highlighter.html
@@ -59,7 +59,7 @@ $(document).ready(function() {
   $('#controls').html(html.join("\n"));
 
   function reloadHighlight(e) {
-    var element = $(e.srcElement);
+    var element = $(e.target);
     var color = element.attr('data-color');
     var showElement = element.attr('checked') == 'checked';
     var tokens = $('#text div.' + color);


### PR DESCRIPTION
event.srcElement was not set in Firefox, but event.target was set in both FF
and Chromium, so I changed the javascript to use this instead.
