### PR TITLE
Adds links to (un)select all tags in pos highlighter tab

### DIFF
--- a/pypln/web/templates/core/visualizations/pos-highlighter.html
+++ b/pypln/web/templates/core/visualizations/pos-highlighter.html
@@ -1,6 +1,7 @@
 {% load i18n %}
 <div id="pos">
   <h3>{% trans "Controls" %}</h3>
+  <a href="#" id="checkall">select all</a> <a href="#" id="uncheckall">unselect all</a>
   <div id="controls"></div>
 
   <h3>{% trans "Highlighted text" %}</h3>
@@ -76,6 +77,21 @@ $(document).ready(function() {
     element.attr('checked', 'checked');
     element.click(reloadHighlight);
   }
+
+  function checkAll(e) {
+    e.preventDefault();
+    $('#controls').find(':checkbox').attr('checked', 'checked');
+    $('#text').find('div').css('background-color', '');
+  }
+
+  function uncheckAll(e) {
+    e.preventDefault();
+    $('#controls').find(':checkbox').removeAttr('checked');
+    $('#text').find('div').css('background-color', 'white');
+  }
+
+  $('#checkall').click(checkAll);
+  $('#uncheckall').click(uncheckAll);
 
   var content = [
   {% for info in pos %}


### PR DESCRIPTION
This is part of NAMD/pypln.backend#117

There's probably a way to organize this better, but I can't see it right now.
Please review this code and suggest changes.
