### PR TITLE
Fixes KeyError when document language was an empty string

### DIFF
--- a/pypln/web/apps/core/views.py
+++ b/pypln/web/apps/core/views.py
@@ -181,8 +181,7 @@ def document_page(request, document_slug):
     properties = set(store.get('id:{}:_properties'.format(document.id), []))
     metadata = store.get('id:{}:file_metadata'.format(document.id), {})
     language = store.get('id:{}:language'.format(document.id), None)
-    if language:
-        metadata['language'] = LANGUAGES[language]
+    metadata['language'] = LANGUAGES[language] if language else 'Unknown'
     data['metadata'] = metadata
     visualizations = []
     for key, value in VISUALIZATIONS.items():

--- a/pypln/web/apps/core/views.py
+++ b/pypln/web/apps/core/views.py
@@ -181,7 +181,7 @@ def document_page(request, document_slug):
     properties = set(store.get('id:{}:_properties'.format(document.id), []))
     metadata = store.get('id:{}:file_metadata'.format(document.id), {})
     language = store.get('id:{}:language'.format(document.id), None)
-    if language is not None:
+    if language:
         metadata['language'] = LANGUAGES[language]
     data['metadata'] = metadata
     visualizations = []


### PR DESCRIPTION
This happened when the document mimetype was not recognized by the extractor
worker in the backend.
