### PR TITLE
Allows the creation of multiple pipelines at once

### DIFF
--- a/pypln/web/apps/core/tests/views.py
+++ b/pypln/web/apps/core/tests/views.py
@@ -151,12 +151,12 @@ class UploadDocumentTest(TestCase):
         corpus = Corpus.objects.get(slug="test-corpus")
         self.assertGreater(corpus.last_modified, start_time)
 
-    @patch('core.views.create_pipeline')
-    def test_pipeline_is_created(self, create_pipeline_mock):
+    @patch('core.views.create_pipelines')
+    def test_pipeline_is_created(self, create_pipelines_mock):
         self.client.login(username="admin", password="admin")
         response = self.client.post(self.url, {'blob': [self.fp]}, follow=True)
         document = Document.objects.all()[0]
-        expected_data = {'_id': str(document.blob.file._id), 'id': document.id}
+        expected_data = [{'_id': str(document.blob.file._id), 'id': document.id}]
 
-        self.assertTrue(create_pipeline_mock.called)
-        self.assertIn(expected_data, create_pipeline_mock.call_args[0])
+        self.assertTrue(create_pipelines_mock.called)
+        self.assertIn(expected_data, create_pipelines_mock.call_args[0])

--- a/pypln/web/apps/core/views.py
+++ b/pypln/web/apps/core/views.py
@@ -39,12 +39,12 @@ from core.forms import CorpusForm, DocumentForm
 from django.conf import settings
 from apps.core.visualizations import VISUALIZATIONS
 
-from utils import LANGUAGES, create_pipeline
+from utils import LANGUAGES, create_pipelines
 from mongodict import MongoDict
 
 from pypln.web.apps.core.search import WhooshIndex
 from pypln.web.apps.core.visualizations import VISUALIZATIONS
-from pypln.web.apps.utils import LANGUAGES, create_pipeline
+from pypln.web.apps.utils import LANGUAGES, create_pipelines
 
 
 def _search_filtering_by_owner(index, query, owner, corpus=None):
@@ -120,6 +120,7 @@ def upload_documents(request, corpus_slug):
     form = DocumentForm(request.user, request.POST, request.FILES)
     if form.is_valid():
         docs = form.save(commit=False)
+        pipelines_data = []
         for doc in docs:
             doc.save()
             # XXX: updating the corpus_set should probably be done in
@@ -130,10 +131,10 @@ def upload_documents(request, corpus_slug):
             for corpus in doc.corpus_set.all():
                 corpus.last_modified = datetime.datetime.now()
                 corpus.save()
-            data = {'_id': str(doc.blob.file._id), 'id': doc.id}
-            create_pipeline(settings.ROUTER_API, settings.ROUTER_BROADCAST, data,
-                            timeout=settings.ROUTER_TIMEOUT)
+            pipelines_data.append({'_id': str(doc.blob.file._id), 'id': doc.id})
 
+        create_pipelines(settings.ROUTER_API, settings.ROUTER_BROADCAST,
+                    pipelines_data, timeout=settings.ROUTER_TIMEOUT)
         number_of_uploaded_docs = len(docs)
         # I know I should be using string.format, but gettext doesn't support
         # it yet: https://savannah.gnu.org/bugs/?30854

--- a/pypln/web/apps/utils/__init__.py
+++ b/pypln/web/apps/utils/__init__.py
@@ -20,7 +20,7 @@
 
 from .tagset import TAGSET, COMMON_TAGS
 from .languages import LANGUAGES
-from .pipeline import create_pipeline, get_config_from_router
+from .pipeline import create_pipelines, get_config_from_router
 
 from django.template.defaultfilters import slugify
 

--- a/pypln/web/apps/utils/pipeline.py
+++ b/pypln/web/apps/utils/pipeline.py
@@ -26,10 +26,9 @@ default_pipeline = {Job('Extractor'): Job('Tokenizer'),
 
 def create_pipelines(api, broadcast, data, timeout):
     manager = PipelineManager(api, broadcast)
-
     for document in data:
         pipeline = Pipeline(default_pipeline, data=document)
-        return manager.start(pipeline)
+        manager.start(pipeline)
 
 
 def get_config_from_router(api, timeout=5):

--- a/pypln/web/apps/utils/pipeline.py
+++ b/pypln/web/apps/utils/pipeline.py
@@ -26,9 +26,11 @@ default_pipeline = {Job('Extractor'): Job('Tokenizer'),
 
 def create_pipelines(api, broadcast, data, timeout):
     manager = PipelineManager(api, broadcast)
+    created_pipelines = []
     for document in data:
         pipeline = Pipeline(default_pipeline, data=document)
-        manager.start(pipeline)
+        created_pipelines.append(manager.start(pipeline))
+    return created_pipelines
 
 
 def get_config_from_router(api, timeout=5):

--- a/pypln/web/apps/utils/pipeline.py
+++ b/pypln/web/apps/utils/pipeline.py
@@ -24,10 +24,12 @@ default_pipeline = {Job('Extractor'): Job('Tokenizer'),
                     Job('Tokenizer'): (Job('POS'), Job('FreqDist')),
                     Job('FreqDist'): Job('Statistics')}
 
-def create_pipeline(api, broadcast, data, timeout):
-    pipeline = Pipeline(default_pipeline, data=data)
+def create_pipelines(api, broadcast, data, timeout):
     manager = PipelineManager(api, broadcast)
-    return manager.start(pipeline)
+
+    for document in data:
+        pipeline = Pipeline(default_pipeline, data=document)
+        return manager.start(pipeline)
 
 
 def get_config_from_router(api, timeout=5):


### PR DESCRIPTION
This means the manager is only created once, so we'll connect much fewer times
when more than one document is uplodaded.

Fixes #48 and helps with #43 (there seems to be some other bottleneck for that
one; in my development environment it takes a long time to process lots of
files before they hit the send pipelines step, but maybe in the server this
will be less noticeable).
