### PR TITLE
Fixes KeyError in wordcloud visualization for Unknown languages

### DIFF
--- a/pypln/web/apps/core/visualizations.py
+++ b/pypln/web/apps/core/visualizations.py
@@ -77,8 +77,8 @@ def _statistics(data):
 
 def _wordcloud(data):
     stopwords_list = list(punctuation)
-    document_language = LANGUAGES[data['language']].lower()
-    if document_language in stopwords.fileids():
+    document_language = LANGUAGES.get(data['language'])
+    if document_language and document_language.lower() in stopwords.fileids():
         stopwords_list += stopwords.words(document_language)
     data['freqdist'] = [[x[0], x[1]] for x in data['freqdist'] \
                                                  if x[0] not in stopwords_list]


### PR DESCRIPTION
When trying to filter stopwords the visualization would not find an empty key
in the dictionary, raising a KeyError
