### PR TITLE
Feature/remove links to dummy pages

### DIFF
--- a/pypln/web/templates/account/signup.html
+++ b/pypln/web/templates/account/signup.html
@@ -1,0 +1,72 @@
+{% extends "site_base.html" %}
+
+{% load i18n %}
+{% load bootstrap_tags %}
+{% load ifsetting_tag %}
+
+{% block head_title %}{% trans "Signup" %}{% endblock %}
+
+{% block body %}
+    <h1>{% trans "Sign Up" %}</h1>
+    
+    {% if user.is_authenticated %}
+        <p>{% trans "You are already logged in." %}</p>
+    {% else %}
+        <p>{% trans "Already have an account?" %} <a href="{% url acct_login %}">{% trans "Log In" %}</a>!</p>
+        
+        <form id="signup_form" method="post" action="{% url acct_signup %}" autocapitalize="off">
+            {% csrf_token %}
+            <fieldset>
+                {{ form|as_bootstrap }}
+            </fieldset>
+            {% if redirect_field_value %}
+                <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}" />
+            {% endif %}
+            <div class="actions">
+                <button type="submit" class="btn primary">{% trans "Sign Up" %}</button>
+            </div>
+        </form>
+
+        {% ifsetting ACCOUNT_USE_OPENID %}
+        <h2>{% trans "Or sign in with your OpenID" %}:</h2>
+        <form action="/openid/register/" method="POST" autocapitalize="off">
+            {% csrf_token %}
+            <fieldset>
+                {% if url_required %}
+                    <div class="clearfix">
+                        <label for="id_username">* OpenID Identifier</label>
+                        <div class="input">
+                            <input class="openid" type="text" name="openid_url" />
+                        </div>
+                    </div>
+                {% else %}
+                    <div class="clearfix">
+                        <label for="id_username">* OpenID Identifier</label>
+                        <div class="input">
+                            <input class="openid" type="text" name="openid_url" />
+                        </div>
+                    </div>
+                {% endif %}
+                <div class="actions">
+                    <input type="submit" value="{% trans "Log in" %}" class="btn primary" />
+                </div>
+            </fieldset>
+        </form>
+        {% endifsetting %}
+        
+        {% url terms as terms_url %}
+        {% url privacy as privacy_url %}
+        <p>{% blocktrans %}By clicking "Sign Up", you are indicating that you have read and agree to the <a href="{{ terms_url }}">Terms of Use</a> and <a href="{{ privacy_url }}">Privacy Policy</a>.{% endblocktrans %}</p>
+        
+        <p>{% blocktrans %}If you have any trouble creating your account, contact us at <a href="mailto:{{ CONTACT_EMAIL }}">{{ CONTACT_EMAIL }}</a>.{% endblocktrans %}</p>
+        
+    {% endif %}
+{% endblock %}
+
+{% block extra_body %}
+    <script type="text/javascript">
+        $(function(){
+            $("#id_username").focus();
+        });
+    </script>
+{% endblock %}

--- a/pypln/web/templates/account/signup.html
+++ b/pypln/web/templates/account/signup.html
@@ -54,9 +54,11 @@
         </form>
         {% endifsetting %}
         
+        {% comment %}
         {% url terms as terms_url %}
         {% url privacy as privacy_url %}
         <p>{% blocktrans %}By clicking "Sign Up", you are indicating that you have read and agree to the <a href="{{ terms_url }}">Terms of Use</a> and <a href="{{ privacy_url }}">Privacy Policy</a>.{% endblocktrans %}</p>
+        {% endcomment %}
         
         <p>{% blocktrans %}If you have any trouble creating your account, contact us at <a href="mailto:{{ CONTACT_EMAIL }}">{{ CONTACT_EMAIL }}</a>.{% endblocktrans %}</p>
         


### PR DESCRIPTION
Hide links to Terms of Use and Privacy Policy pages until Issue #65 and #66 are solved.

At present these pages display dummy content, not cool for somebody using the demo instance at http://demo.pypln.org.
