### PR TITLE
Bugfix/duplicate corpus

### DIFF
--- a/pypln/web/core/tests/utils.py
+++ b/pypln/web/core/tests/utils.py
@@ -52,7 +52,7 @@ class TestWithMongo(TestCase):
         filename = os.path.join(settings.PROJECT_ROOT, 'core/fixtures/mongodb/analysis.json')
         with open(filename, 'r') as mongo_fixture:
             for obj in json.load(mongo_fixture):
-                self.store._collection.insert(obj)
+                self.store[obj['_id']] = obj['value']
 
     def _post_teardown(self, *args, **kwargs):
         gridfs_storage._connection.drop_database(gridfs_storage.database)

--- a/pypln/web/core/views.py
+++ b/pypln/web/core/views.py
@@ -22,6 +22,7 @@ from django.http import Http404
 from rest_framework import generics
 from rest_framework import permissions
 from rest_framework.decorators import api_view
+from rest_framework.exceptions import ParseError
 from rest_framework.reverse import reverse
 from rest_framework.response import Response
 from rest_framework import serializers
@@ -47,7 +48,11 @@ class CorpusList(generics.ListCreateAPIView):
         return Corpus.objects.filter(owner=self.request.user)
 
     def pre_save(self, obj):
-        obj.owner = self.request.user
+        if Corpus.objects.filter(name=obj.name,
+                owner=self.request.user).exists():
+            raise ParseError(detail="Corpora names must be unique for each user.")
+        else:
+            obj.owner = self.request.user
 
 class CorpusDetail(generics.RetrieveUpdateDestroyAPIView):
     model = Corpus
@@ -58,7 +63,11 @@ class CorpusDetail(generics.RetrieveUpdateDestroyAPIView):
         return Corpus.objects.filter(owner=self.request.user)
 
     def pre_save(self, obj):
-        obj.owner = self.request.user
+        if Corpus.objects.filter(name=obj.name,
+                owner=self.request.user).exists():
+            raise ParseError(detail="Corpora names must be unique for each user.")
+        else:
+            obj.owner = self.request.user
 
 class DocumentList(generics.ListCreateAPIView):
     model = Document


### PR DESCRIPTION
Keep the user from trying to have duplicate corpora names. If the user tries to create a new corpus with the same name as one that exists, or tries to edit one in a way that this happens, the request will be replied with a 400 (422 is arguably a better response, but it is not exactly standard, so we'll keep 400 for now).
