### PR TITLE
Catches KeyError on the properties list when there is no info for the document

### DIFF
--- a/pypln/web/core/serializers.py
+++ b/pypln/web/core/serializers.py
@@ -66,6 +66,9 @@ class PropertyListSerializer(serializers.Serializer):
 
     def get_property_urls(self, obj):
         request = self.context['request']
-        return [reverse('property-detail', kwargs={"pk": obj.id,
-            "property": prop}, request=request) for prop
-            in obj.properties.keys()]
+        try:
+            return [reverse('property-detail', kwargs={"pk": obj.id,
+                "property": prop}, request=request) for prop
+                in obj.properties.keys()]
+        except KeyError:
+            return []


### PR DESCRIPTION
I've decided to catch this in the serializer and keep the KeyError in
StoreProxy when there is no '_properties' for the document in mongodb because
there is a difference between having an empty list of properties and having no
information for that document (even though that difference is not important to
the user that is trying to list the document properties in the web app).

Closes #99
