### PR TITLE
Allows users to authenticate using a Token

### DIFF
--- a/contrib/reset_gridfs_collection.py
+++ b/contrib/reset_gridfs_collection.py
@@ -17,6 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with PyPLN.  If not, see <http://www.gnu.org/licenses/>.
 import os
+from StringIO import StringIO
 import sys
 
 from pypln.web.core.models import Document, gridfs_storage
@@ -35,5 +36,5 @@ sys.stdout.write("Adding files to gridfs collection and executing pipelines ...\
 
 for doc in Document.objects.all():
     gridfs_storage.save(os.path.basename(doc.blob.name),
-            "This is a test file with some test text.")
+            StringIO("This is a test file with some test text."))
     create_pipeline({"_id": str(doc.blob.file._id), "id": doc.id})

--- a/pypln/web/core/models.py
+++ b/pypln/web/core/models.py
@@ -19,10 +19,13 @@
 from UserDict import DictMixin
 
 from django.conf import settings
+from django.contrib.auth.models import User
+from django.dispatch import receiver
 from django.db import models
 
 from mongodict import MongoDict
 from rest_framework.reverse import reverse
+from rest_framework.authtoken.models import Token
 
 from pypln.web.core.storage import GridFSStorage
 
@@ -91,3 +94,10 @@ class Document(models.Model):
                    database=settings.MONGODB_CONFIG['database'],
                    collection=settings.MONGODB_CONFIG['analysis_collection'])
         return StoreProxy(self.id, self._store)
+
+
+# Create a authentication Token for each user it's created.
+@receiver(models.signals.post_save, sender=User)
+def create_auth_token(sender, instance=None, created=False, **kwargs):
+    if created:
+        Token.objects.create(user=instance)

--- a/pypln/web/core/tests/utils.py
+++ b/pypln/web/core/tests/utils.py
@@ -16,6 +16,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with PyPLN.  If not, see <http://www.gnu.org/licenses/>.
+from cStringIO import StringIO
 import json
 import os
 
@@ -42,7 +43,7 @@ class TestWithMongo(TestCase):
 
         for doc in Document.objects.all():
             gridfs_storage.save(os.path.basename(doc.blob.name),
-                    "This is a test file with some test text.")
+                    StringIO("This is a test file with some test text."))
 
         self.store = MongoDict(host=settings.MONGODB_CONFIG['host'],
                port=settings.MONGODB_CONFIG['port'],

--- a/pypln/web/core/tests/views/__init__.py
+++ b/pypln/web/core/tests/views/__init__.py
@@ -1,3 +1,4 @@
+from auth_token import *
 from corpus import *
 from document import *
 from properties import *

--- a/pypln/web/core/tests/views/auth_token.py
+++ b/pypln/web/core/tests/views/auth_token.py
@@ -1,0 +1,42 @@
+# -*- coding:utf-8 -*-
+#
+# Copyright 2012 NAMD-EMAP-FGV
+#
+# This file is part of PyPLN. You can get more information at: http://pypln.org/.
+#
+# PyPLN is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PyPLN is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PyPLN.  If not, see <http://www.gnu.org/licenses/>.
+from django.contrib.auth.models import User
+from django.core.urlresolvers import reverse
+from django.test import TestCase
+
+from rest_framework.authtoken.models import Token
+
+__all__ = ["AuthTokenViewTest"]
+
+
+class AuthTokenViewTest(TestCase):
+    fixtures = ['users']
+
+    def test_requires_login(self):
+        response = self.client.get(reverse('auth_token'))
+        self.assertEqual(response.status_code, 403)
+
+    def test_lists_the_authenticated_users_token(self):
+        self.client.login(username="user", password="user")
+        response = self.client.get(reverse('auth_token'))
+        self.assertEqual(response.status_code, 200)
+
+        expected_data = Token.objects.get(
+                user=User.objects.get(username="user")).key
+        self.assertEqual(response.data['token'], expected_data)

--- a/pypln/web/core/urls.py
+++ b/pypln/web/core/urls.py
@@ -25,6 +25,7 @@ from pypln.web.core.views import PropertyList, PropertyDetail
 
 urlpatterns = patterns('pypln.web.core.views',
     url(r'^$', 'api_root'),
+    url(r'^user/api-token/$', 'auth_token', name='auth_token'),
     url(r'^corpora/$', CorpusList.as_view(), name='corpus-list'),
     url(r'^corpora/(?P<pk>\d+)/$', CorpusDetail.as_view(), name='corpus-detail'),
     url(r'^documents/$', DocumentList.as_view(), name='document-list'),

--- a/pypln/web/core/views.py
+++ b/pypln/web/core/views.py
@@ -21,7 +21,8 @@ from django.http import Http404
 
 from rest_framework import generics
 from rest_framework import permissions
-from rest_framework.decorators import api_view
+from rest_framework.authtoken.models import Token
+from rest_framework.decorators import api_view, permission_classes
 from rest_framework.exceptions import ParseError
 from rest_framework.reverse import reverse
 from rest_framework.response import Response
@@ -38,6 +39,23 @@ def api_root(request, format=None):
         'corpora': reverse('corpus-list', request=request),
         'documents': reverse('document-list', request=request),
     })
+
+@api_view(['GET'])
+@permission_classes((permissions.IsAuthenticated,))
+def auth_token(request, format=None):
+    """
+    Lists the current user's API Authentication Token.
+
+    To authenticate using this token the user needs to send a header in the
+    form `Authorization: Token <token>`.  Suposing a token with the value
+    `deadbeef` you could access the API using the following command: `curl
+    http://demo.pypln.org/documents/ -H "Authorization: Token deadbeef"`.
+    """
+    token = Token.objects.get(user=request.user).key
+    return Response({
+        'token': token,
+    })
+
 
 class CorpusList(generics.ListCreateAPIView):
     """

--- a/pypln/web/settings/base.py
+++ b/pypln/web/settings/base.py
@@ -155,6 +155,7 @@ INSTALLED_APPS = (
     'django.contrib.admin',
 
     'rest_framework',
+    'rest_framework.authtoken',
     'registration',
 
     'pypln.web.core',
@@ -193,6 +194,11 @@ LOGGING = {
 ACCOUNT_ACTIVATION_DAYS = 7
 
 REST_FRAMEWORK = {
+    'DEFAULT_AUTHENTICATION_CLASSES': (
+        'rest_framework.authentication.SessionAuthentication',
+        'rest_framework.authentication.BasicAuthentication',
+        'rest_framework.authentication.TokenAuthentication',
+    ),
     "PAGINATE_BY": 100,
     "PAGINATE_BY_PARAM": "page_size",
 }

--- a/pypln/web/templates/rest_framework/api.html
+++ b/pypln/web/templates/rest_framework/api.html
@@ -12,6 +12,7 @@
                 <b class="caret"></b>
             </a>
             <ul class="dropdown-menu">
+                <li><a href="{% url 'auth_token' %}">API Token</a></li>
                 <li><a href="{% url 'auth_password_change' %}">Change password</a></li>
                 <li>{% optional_logout request %}</li>
             </ul>


### PR DESCRIPTION
We still need to make sure demo.pypln.org is only available through HTTPS.
