### PR TITLE
Fixes pipeline for FreqDist worker

### DIFF
--- a/pypln/web/backend_adapter/pipelines.py
+++ b/pypln/web/backend_adapter/pipelines.py
@@ -21,9 +21,10 @@ from pypelinin import Job, Pipeline, PipelineManager, Client
 
 default_pipeline = {
     Job("Extractor"): (Job("PalavrasRaw"), Job("Tokenizer")),
-    Job("PalavrasRaw"): (Job("POS"), Job("FreqDist"),
+    Job("PalavrasRaw"): (Job("POS"),
                          Job("Lemmatizer"), Job("NounPhrase"),
                          Job("SemanticTagger")),
+    Job("Tokenizer"): Job("FreqDist"),
     Job("FreqDist"): Job("Statistics")
 }
 


### PR DESCRIPTION
This worker depends on Tokenizer, not PalavrasRaw. Before this patch FreqDist
would never run for a text in English or in a system that does not have
Palavras.

Another problem is the POS worker. It does depend on PalavrasRaw for portuguese, but it should run even without PalavrasRaw for english texts. We have to think of a way of running it for both, but not running it twice. @turicas any advice on this is welcome.
