### PR TITLE
Puts the login template in the expected place for django.contrib.auth's ...

### DIFF
--- a/pypln/web/templates/registration/login.html
+++ b/pypln/web/templates/registration/login.html
@@ -1,0 +1,1 @@
+../rest_framework/login.html


### PR DESCRIPTION
...login

This is a symbolic link because we only have one login page but django
registration's password reset view redirects the user to django.contrib.auth's
login page and it expects the template to be in registration/login.html.

Fixes #98
