### PR TITLE
Upgrade requirements

### DIFF
--- a/pypln/web/backend_adapter/pipelines.py
+++ b/pypln/web/backend_adapter/pipelines.py
@@ -36,6 +36,10 @@ def call_default_pipeline(doc_id):
         )
     )()
 
+def create_pipeline_from_document(doc):
+    data = {"_id": str(doc.blob.file._id), "id": doc.id}
+    create_pipeline(data)
+
 def create_pipeline(data):
     # Add file_id as a property to the document before starting
     # to process it. The first worker will need this property

--- a/pypln/web/core/serializers.py
+++ b/pypln/web/core/serializers.py
@@ -30,23 +30,25 @@ class CorpusSerializer(serializers.HyperlinkedModelSerializer):
         model = Corpus
 
 class DocumentSerializer(serializers.HyperlinkedModelSerializer):
-    owner = serializers.Field(source="owner.username")
-    corpus = serializers.HyperlinkedRelatedField(view_name="corpus-detail")
-    size = serializers.Field(source="blob.size")
+    owner = serializers.ReadOnlyField(source="owner.username")
+    corpus = serializers.HyperlinkedRelatedField(view_name="corpus-detail", queryset=Corpus.objects.all())
+    size = serializers.ReadOnlyField(source="blob.size")
+    blob = serializers.FileField(use_url=False)
     properties = serializers.HyperlinkedIdentityField(view_name="property-list")
 
     def __init__(self, *args, **kwargs):
+        super(DocumentSerializer, self).__init__(*args, **kwargs)
         # If the serializer is treating input from a view, there will be a
         # context from which we can take the owner, and filter the possible
         # corpora with it.
         if 'context' in kwargs:
             user = kwargs['context']['request'].user
-            self.base_fields['corpus'].queryset = Corpus.objects.filter(owner=user)
+            self.fields['corpus'].queryset = Corpus.objects.filter(owner=user)
         # If we get a document that already exists, we can filter based on it's
         # owner.
         elif args:
             document = args[0]
-            self.base_fields['corpus'].queryset = Corpus.objects.filter(
+            self.fields['corpus'].queryset = Corpus.objects.filter(
                     owner=document.owner)
         # In other cases we don't filter the queryset. All the user input
         # should come through a view, and this view needs to send us a
@@ -56,7 +58,15 @@ class DocumentSerializer(serializers.HyperlinkedModelSerializer):
         else:
             raise ValueError("DocumentSerializer needs either a Document or a "
                     "context.")
-        super(DocumentSerializer, self).__init__(*args, **kwargs)
+
+    def create(self, validated_data):
+        validated_data['owner'] = self.context['request'].user
+        return super(DocumentSerializer, self).create(validated_data)
+
+    def validate_corpus(self, value):
+        if value.owner != self.context['request'].user:
+            raise serializers.ValidationError("The corpus must belong to the user that is creating the document.")
+        return value
 
     class Meta:
         model = Document

--- a/pypln/web/core/serializers.py
+++ b/pypln/web/core/serializers.py
@@ -23,11 +23,19 @@ from rest_framework.reverse import reverse
 from pypln.web.core.models import Corpus, Document
 
 class CorpusSerializer(serializers.HyperlinkedModelSerializer):
-    owner = serializers.Field(source="owner.username")
+    owner = serializers.ReadOnlyField(source="owner.username")
     documents = serializers.HyperlinkedIdentityField(
             view_name="corpus-document-list", )
     class Meta:
         model = Corpus
+
+    def validate_name(self, value):
+        if Corpus.objects.filter(name=value,
+                                 owner=self.context['request'].user).exists():
+            raise serializers.ValidationError("Corpora names must be unique for each user.")
+        else:
+            return value
+
 
 class DocumentSerializer(serializers.HyperlinkedModelSerializer):
     owner = serializers.ReadOnlyField(source="owner.username")

--- a/pypln/web/core/tests/test_serializers.py
+++ b/pypln/web/core/tests/test_serializers.py
@@ -21,6 +21,9 @@ from StringIO import StringIO
 
 from django.contrib.auth.models import User
 
+from rest_framework.reverse import reverse as rest_framework_reverse
+from rest_framework.test import APIRequestFactory, force_authenticate
+
 from pypln.web.core.models import Document
 from pypln.web.core.serializers import DocumentSerializer
 from pypln.web.core.tests.utils import TestWithMongo
@@ -57,7 +60,10 @@ class DocumentSerializerTest(TestWithMongo):
 
     def test_serialized_data_should_include_file_size(self):
         document = Document.objects.all()[0]
-        serializer = DocumentSerializer(document)
-
+        factory = APIRequestFactory()
+        request = factory.get(rest_framework_reverse('document-detail',
+            kwargs={'pk': document.id}))
+        request.user = document.owner
+        serializer = DocumentSerializer(document, context={'request': request})
         self.assertIn("size", serializer.data)
         self.assertEqual(serializer.data["size"], document.blob.size)

--- a/pypln/web/core/tests/views/test_corpus.py
+++ b/pypln/web/core/tests/views/test_corpus.py
@@ -41,7 +41,7 @@ class CorpusListViewTest(TestCase):
 
         expected_data = Corpus.objects.filter(
                 owner=User.objects.get(username="user"))
-        object_list = response.renderer_context['view'].object_list
+        object_list = response.renderer_context['view'].get_queryset()
 
         self.assertEqual(list(expected_data), list(object_list))
 
@@ -89,7 +89,7 @@ class CorpusDetailViewTest(TestCase):
             kwargs={'pk': corpus.id}))
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.renderer_context['view'].object, corpus)
+        self.assertEqual(response.renderer_context['view'].get_object(), corpus)
 
     def test_returns_404_for_inexistent_corpus(self):
         self.client.login(username="user", password="user")
@@ -143,10 +143,7 @@ class CorpusDetailViewTest(TestCase):
         response = self.client.put(reverse('corpus-detail',
             kwargs={'pk': corpus.id}), json.dumps({"name": "New name",
             "description": "New description"}), content_type="application/json")
-
-        new_corpus = response.renderer_context['view'].object
-        self.assertEqual(response.status_code, 201)
-        self.assertNotEqual(new_corpus.id, corpus.id)
+        self.assertEqual(response.status_code, 404)
 
         reloaded_corpus = Corpus.objects.filter(owner__username="admin")[0]
         self.assertNotEqual(reloaded_corpus.name, "New name")

--- a/pypln/web/core/tests/views/test_properties.py
+++ b/pypln/web/core/tests/views/test_properties.py
@@ -45,7 +45,7 @@ class DocumentListTest(TestWithMongo):
             kwargs={'pk': self.document.id}))
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.renderer_context['view'].object, self.document)
+        self.assertEqual(response.renderer_context['view'].get_object(), self.document)
         fake_request = RequestFactory().get(reverse('property-list',
             kwargs={'pk': self.document.id}))
 
@@ -102,7 +102,8 @@ class DocumentDetailTest(TestWithMongo):
             kwargs={'pk': self.document.id, 'property': 'text'}))
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.renderer_context['view'].object, self.document)
+        self.assertEqual(response.renderer_context['view'].get_object(),
+                         self.document)
         self.assertEqual(response.data['value'],
                 self.document.properties['text'])
 

--- a/pypln/web/core/views.py
+++ b/pypln/web/core/views.py
@@ -79,12 +79,8 @@ class CorpusList(generics.ListCreateAPIView):
     def get_queryset(self):
         return Corpus.objects.filter(owner=self.request.user)
 
-    def pre_save(self, obj):
-        if Corpus.objects.filter(name=obj.name,
-                owner=self.request.user).exists():
-            raise ParseError(detail="Corpora names must be unique for each user.")
-        else:
-            obj.owner = self.request.user
+    def perform_create(self, serializer):
+        instance = serializer.save(owner=self.request.user)
 
 class CorpusDetail(generics.RetrieveUpdateDestroyAPIView):
     """
@@ -117,12 +113,8 @@ class CorpusDetail(generics.RetrieveUpdateDestroyAPIView):
     def get_queryset(self):
         return Corpus.objects.filter(owner=self.request.user)
 
-    def pre_save(self, obj):
-        if Corpus.objects.filter(name=obj.name,
-                owner=self.request.user).exists():
-            raise ParseError(detail="Corpora names must be unique for each user.")
-        else:
-            obj.owner = self.request.user
+    def perform_update(self, serializer):
+        instance = serializer.save(owner=self.request.user)
 
 class DocumentList(generics.ListCreateAPIView):
     """

--- a/pypln/web/templates/rest_framework/api.html
+++ b/pypln/web/templates/rest_framework/api.html
@@ -14,7 +14,7 @@
             <ul class="dropdown-menu">
                 <li><a href="{% url 'auth_token' %}">API Token</a></li>
                 <li><a href="{% url 'auth_password_change' %}">Change password</a></li>
-                <li>{% optional_logout request %}</li>
+                <li>{% optional_logout request user %}</li>
             </ul>
         </li>
     {% else %}

--- a/pypln/web/templates/rest_framework/login.html
+++ b/pypln/web/templates/rest_framework/login.html
@@ -1,5 +1,6 @@
 {% load url from future %}
 {% load rest_framework %}
+{% load static from staticfiles %}
 <html>
 
     <head>

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -10,5 +10,5 @@ pymongo==2.8.1
 mongodict
 pypln.backend
 gunicorn
-django-registration
+django-registration-redux
 markdown

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -1,8 +1,5 @@
 django
-# This version is hardcoded because of a bug
-# (https://github.com/tomchristie/django-rest-framework/issues/1237). As soon
-# as it is fixed we should relax this requirement.
-djangorestframework==2.3.6
+djangorestframework
 pymongo==2.8.1
 mongodict
 pypln.backend

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -1,7 +1,4 @@
-# django-registration throws `django.core.exceptions.AppRegistryNotReady` with
-# django 1.7, so we'll pin django to 1.6 for now until it's fixed upstream or
-# we remove django-registration as a dependecy.
-django==1.6
+django
 # This version is hardcoded because of a bug
 # (https://github.com/tomchristie/django-rest-framework/issues/1237). As soon
 # as it is fixed we should relax this requirement.


### PR DESCRIPTION
This pull request updates the project's requirements to the newest versions where possible. We removed the version specifications for all the packages except for pymongo because upgrading it to 3.0 requires upgrading mongodb itself to the version 3.0 and, even though we want to do that, this would mean much more work than this, which we cannot accommodate for now.

@israelst @fccoelho it would be great if you could review this.
